### PR TITLE
Deleted duplicated dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
-		<junit.version>5.9.2</junit.version>
 		<org.jacoco.version>0.8.7</org.jacoco.version>
 	</properties>
 	<dependencies>
@@ -43,12 +42,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Fixed "La dependencia junit-jupiter-engine se encuentra duplicada ya que se puede obtener de forma transitiva a partir de spring-boot-starter-test."